### PR TITLE
fix: Align module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/casbin/zap-logger
+module github.com/casbin/zap-logger/v2
 
 go 1.14
 


### PR DESCRIPTION
Hmm, forgot to update this. Go modules 🤦 