### PR TITLE
fix: Fix compatibility with Casbin v2.75.0

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -155,3 +155,11 @@ func (l *Logger) LogRole(roles []string) {
 
 	l.logger.Info("LogRole", zap.Strings("roles", roles))
 }
+
+func (l *Logger) LogError(err error, msg ...string) {
+	if !l.IsEnabled() {
+		return
+	}
+
+	l.logger.Error("LogError", zap.Error(err), zap.Strings("msg", msg))
+}


### PR DESCRIPTION
This PR added new `LogError` method to `Logger`:

https://github.com/casbin/casbin/pull/1294